### PR TITLE
Update glu.py

### DIFF
--- a/glu_tf/glu.py
+++ b/glu_tf/glu.py
@@ -9,7 +9,7 @@ class GLU(tf.keras.layers.Layer):
         self.dense = tf.keras.layers.Dense(2, use_bias=bias)
 
     def call(self, x):
-        out, gate = tf.split(x, num_split=2, axis=self.dim)
+        out, gate = tf.split(x, num_or_size_splits=2, axis=self.dim)
         gate = tf.sigmoid(gate)
         x = tf.multiply(out, gate)
         return x
@@ -23,7 +23,7 @@ class Bilinear(tf.keras.layers.Layer):
         self.dense = tf.keras.layers.Dense(2, use_bias=bias)
 
     def call(self, x):
-        out, gate = tf.split(x, num_split=2, axis=self.dim)
+        out, gate = tf.split(x, num_or_size_splits=2, axis=self.dim)
         x = tf.multiply(out, gate)
         return x
 
@@ -36,7 +36,7 @@ class ReGLU(tf.keras.layers.Layer):
         self.dense = tf.keras.layers.Dense(2, use_bias=bias)
 
     def call(self, x):
-        out, gate = tf.split(x, num_split=2, axis=self.dim)
+        out, gate = tf.split(x, num_or_size_splits=2, axis=self.dim)
         gate = tf.nn.relu(gate)
         x = tf.multiply(out, gate)
         return x
@@ -50,7 +50,7 @@ class GeGLU(tf.keras.layers.Layer):
         self.dense = tf.keras.layers.Dense(2, use_bias=bias)
 
     def call(self, x):
-        out, gate = tf.split(x, num_split=2, axis=self.dim)
+        out, gate = tf.split(x, num_or_size_splits=2, axis=self.dim)
         gate = tf.keras.activations.gelu(gate)
         x = tf.multiply(out, gate)
         return x
@@ -64,7 +64,7 @@ class SwiGLU(tf.keras.layers.Layer):
         self.dense = tf.keras.layers.Dense(2, use_bias=bias)
 
     def call(self, x):
-        out, gate = tf.split(x, num_split=2, axis=self.dim)
+        out, gate = tf.split(x, num_or_size_splits=2, axis=self.dim)
         gate = tf.keras.activations.swish(gate)
         x = tf.multiply(out, gate)
         return x
@@ -78,7 +78,7 @@ class SeGLU(tf.keras.layers.Layer):
         self.dense = tf.keras.layers.Dense(2, use_bias=bias)
 
     def call(self, x):
-        out, gate = tf.split(x, num_split=2, axis=self.dim)
+        out, gate = tf.split(x, num_or_size_splits=2, axis=self.dim)
         gate = tf.keras.activations.selu(gate)
         x = tf.multiply(out, gate)
         return x


### PR DESCRIPTION
Update tf.split keyword arg

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/Rishit-dagli/GLU/issues) to link here? Or an external link? -->
Initialiing the layers raises an TypeError.

## :pencil: Changes
<!-- Which code did you change? How? -->
Change `tf.split(x, num_split=2, axis=self.dim) `to `tf.split(x, num_or_size_splits=2, axis=self.dim)`

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->
Since tensorflow 2.3 and above passing  **num_split** as an argument to tf.split causes the method to fail with a `TypeError: Got an unexpected keyword argument 'num_split'`
